### PR TITLE
GiniCapture: added popup with error message for unsupported QR code format (PIA-1563)

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,13 +4,13 @@ PODS:
     - Gini-iOS-SDK/Core (= 1.4.0)
   - Gini-iOS-SDK/Core (1.4.0):
     - Bolts/Tasks (~> 1.9)
-  - GiniCapture (1.0.2):
-    - GiniCapture/Core (= 1.0.2)
-  - GiniCapture/Core (1.0.2)
-  - GiniCapture/Networking (1.0.2):
+  - GiniCapture (1.0.3):
+    - GiniCapture/Core (= 1.0.3)
+  - GiniCapture/Core (1.0.3)
+  - GiniCapture/Networking (1.0.3):
     - GiniCapture/Core
     - GiniPayApiLib/DocumentsAPI (>= 1.0.2)
-  - GiniCapture/Tests (1.0.2)
+  - GiniCapture/Tests (1.0.3)
   - GiniPayApiLib/DocumentsAPI (1.0.8)
 
 DEPENDENCIES:
@@ -33,7 +33,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Bolts: 8c1e8aab2f603387b8b9924f57d1d64f43d3ffdc
   Gini-iOS-SDK: 270169987acb2ebd83d1e11d029daa81b6f89682
-  GiniCapture: 46ef7c19807152f0e2a1b9fdcc9db763be6c9077
+  GiniCapture: ab182def863005b523a94bf7b3cfe626fe51b2df
   GiniPayApiLib: 5fc8b6b4fa0448e9e1e226618ea7f2d1658ff20c
 
 PODFILE CHECKSUM: 4388413edb9a8300e79cf2b4ad755c81370a6ec0

--- a/GiniCapture/Assets/de.lproj/Localizable.strings
+++ b/GiniCapture/Assets/de.lproj/Localizable.strings
@@ -38,6 +38,7 @@
 "ginicapture.camera.fileImportButtonLabel" = "Importieren";
 "ginicapture.camera.capturedImagesStackLabel" = "Erfasste Dokumente";
 "ginicapture.camera.qrCodeDetectedPopup.message" = "QR verwenden?";
+"ginicapture.camera.unsupportedQrCodeDetectedPopup.message" = "Dieser QR-Code enthält keine Bezahlinformationen.";
 "ginicapture.camera.qrCodeDetectedPopup.buttonTitle" = "Hier geht’s weiter.";
 "ginicapture.camera.mixedarrayspopup.cancel" = "Abbrechen";
 "ginicapture.camera.mixedarrayspopup.usePhotos" = "Benutze Photos";

--- a/GiniCapture/Assets/en.lproj/Localizable.strings
+++ b/GiniCapture/Assets/en.lproj/Localizable.strings
@@ -38,6 +38,7 @@
 "ginicapture.camera.fileImportButtonLabel" = "Import";
 "ginicapture.camera.capturedImagesStackLabel" = "Captured documents";
 "ginicapture.camera.qrCodeDetectedPopup.message" = "Use QR code?";
+"ginicapture.camera.unsupportedQrCodeDetectedPopup.message" = "This QR Code does not contain any payment information.";
 "ginicapture.camera.qrCodeDetectedPopup.buttonTitle" = "Continue";
 "ginicapture.camera.mixedarrayspopup.cancel" = "Cancel";
 "ginicapture.camera.mixedarrayspopup.usePhotos" = "Use photos";

--- a/GiniCapture/Classes/Core/GiniConfiguration.swift
+++ b/GiniCapture/Classes/Core/GiniConfiguration.swift
@@ -335,6 +335,20 @@ import UIKit
      Sets the text color of the QR Code popup background
      */
     @objc public var qrCodePopupBackgroundColor = GiniColor(lightModeColor: .white, darkModeColor: UIColor.from(hex: 0x1c1c1e))
+    /**
+     Sets the button color of the unsupported QR Code popup
+     */
+    @objc public var unsupportedQrCodePopupButtonColor : UIColor = .red
+    
+    /**
+     Sets the text color of the unsupported QR Code popup
+     */
+    @objc public var unsupportedQrCodePopupTextColor = GiniColor(lightModeColor: .red, darkModeColor: .red)
+    
+    /**
+     Sets the  background color of the unsupported QR Code popup
+     */
+    @objc public var unsupportedQrCodePopupBackgroundColor = GiniColor(lightModeColor: .white, darkModeColor: UIColor.from(hex: 0x1c1c1e))
     
     // MARK: Onboarding screens
 

--- a/GiniCapture/Classes/Core/Helpers/Localization/String Resources/CameraStrings.swift
+++ b/GiniCapture/Classes/Core/Helpers/Localization/String Resources/CameraStrings.swift
@@ -15,7 +15,7 @@ enum CameraStrings: LocalizableStringResource {
     mixedArraysPopupCancelButton, mixedArraysPopupUsePhotosButton, mixedDocumentsErrorMessage, notAuthorizedButton,
     notAuthorizedMessage, photoLibraryAccessDeniedMessage, qrCodeDetectedPopupMessage, qrCodeDetectedPopupButton,
     tooManyPagesErrorMessage, unknownErrorMessage, wrongFormatErrorMessage, popupTitleImportPDF, popupOptionPhotos,
-    popupOptionFiles, popupTitleImportPDForPhotos, popupCancel
+    popupOptionFiles, popupTitleImportPDForPhotos, popupCancel, unsupportedQrCodeDetectedPopupMessage
     
     var tableName: String {
         return "camera"
@@ -86,6 +86,8 @@ enum CameraStrings: LocalizableStringResource {
             return ("popupOptionPhotos", "File picker popup photos option")
         case .popupCancel:
             return ("popupCancel", "File picker popup cancel option")
+        case .unsupportedQrCodeDetectedPopupMessage:
+            return ("unsupportedQrCodeDetectedPopup.message", "Popup message")
         }
     }
     
@@ -96,7 +98,7 @@ enum CameraStrings: LocalizableStringResource {
              .exceededFileSizeErrorMessage, .documentValidationGeneralErrorMessage,
              .mixedArraysPopupCancelButton, .mixedArraysPopupUsePhotosButton, .mixedDocumentsErrorMessage,
              .notAuthorizedButton, .notAuthorizedMessage, .photoLibraryAccessDeniedMessage, .qrCodeDetectedPopupMessage,
-             .qrCodeDetectedPopupButton, .tooManyPagesErrorMessage, .unknownErrorMessage, .wrongFormatErrorMessage:
+             .qrCodeDetectedPopupButton, .tooManyPagesErrorMessage, .unknownErrorMessage, .wrongFormatErrorMessage, .unsupportedQrCodeDetectedPopupMessage:
             return true
         case .capturedImagesStackSubtitleLabel, .fileImportTipLabel, .importFileButtonLabel, .popupTitleImportPDF,
              .popupTitleImportPDForPhotos, .popupOptionPhotos, .popupOptionFiles, .popupCancel:

--- a/GiniCapture/Classes/Core/Screens/Camera/Camera.swift
+++ b/GiniCapture/Classes/Core/Screens/Camera/Camera.swift
@@ -270,8 +270,11 @@ extension Camera: AVCaptureMetadataOutputObjectsDelegate {
                 DispatchQueue.main.async { [weak self] in
                     self?.didDetectQR?(qrDocument)
                 }
-            } catch {
-            }
+            } catch DocumentValidationError.qrCodeFormatNotValid {
+                DispatchQueue.main.async { [weak self] in
+                    self?.didDetectQR?(qrDocument)
+                }
+            } catch {}
         }
     }
 }

--- a/GiniCapture/Classes/Core/Screens/Camera/CameraViewController.swift
+++ b/GiniCapture/Classes/Core/Screens/Camera/CameraViewController.swift
@@ -235,28 +235,6 @@ extension CameraViewController {
     public func hideFileImportTip() {
         self.toolTipView?.alpha = 0
     }
-    
-    /**
-     Show the QR code Tip. Should be called when fileImportTip is dismissed.
-     */
-    public func showQrCodeTip() {
-        if ToolTipView.shouldShowQRCodeToolTip {
-            createQRCodeTip(giniConfiguration: giniConfiguration)
-            self.toolTipView?.show {
-                self.opaqueView?.alpha = 1
-                self.cameraButtonsViewController.captureButton.isEnabled = false
-            }
-            ToolTipView.shouldShowQRCodeToolTip = false
-        }
-    }
-    
-    /**
-     Hide the QR code Tip. Should be called when onboarding is presented.
-     */
-    public func hideQrCodeTip() {
-        self.toolTipView?.alpha = 0
-    }
-    
 }
 
 // MARK: - Image capture


### PR DESCRIPTION
 GiniCapture:
  *  added popup with error message for unsupported QR code format (PIA-1563)
GiniConfiguration:
  * added configuration for unsupported popup: background color, text color and button color (PIA-1563)

### Description

added popup for unsupported qr code

### How to test

### Merging
Automatic

### Issues
https://ginis.atlassian.net/browse/PIA-1563
