### PR TITLE
Fix showing errors on the analysis screen

### DIFF
--- a/Example/Example Swift/ComponentAPIDocumentsService.swift
+++ b/Example/Example Swift/ComponentAPIDocumentsService.swift
@@ -182,6 +182,7 @@ extension ComponentAPIDocumentsService {
                     print("❌ Cancelled analysis process")
                 default:
                     print("❌ Finished analysis process with error: \(error)")
+                    completion(.failure(error))
                 }
             }
         }

--- a/GiniCapture/Classes/Networking/DocumentServiceProtocol.swift
+++ b/GiniCapture/Classes/Networking/DocumentServiceProtocol.swift
@@ -42,6 +42,7 @@ extension DocumentServiceProtocol {
                     Log(message: "Cancelled analysis process", event: .error)
                 default:
                     Log(message: "Finished analysis process with error: \(error)", event: .error)
+                    completion(.failure(error))
                 }
             }
         }


### PR DESCRIPTION
While reproducing [PIA-1353](https://ginis.atlassian.net/browse/PIA-1353) I found the cause of errors not being shown on the analysis screen.