### PR TITLE
Centralize error logging logic

### DIFF
--- a/GiniCapture/Classes/Core/GiniCapture.swift
+++ b/GiniCapture/Classes/Core/GiniCapture.swift
@@ -190,7 +190,6 @@ public typealias GiniCaptureNetworkDelegate = AnalysisDelegate & UploadDelegate
         let screenCoordinator = GiniScreenAPICoordinator(withDelegate: delegate,
                                                          giniConfiguration: GiniConfiguration.shared)
         screenCoordinator.trackingDelegate = trackingDelegate
-        screenCoordinator.errorLoggerDelegate = GiniConfiguration.shared.errorLogger
         return screenCoordinator.start(withDocuments: importedDocuments)
     }
     

--- a/GiniCapture/Classes/Core/GiniCapture.swift
+++ b/GiniCapture/Classes/Core/GiniCapture.swift
@@ -181,21 +181,16 @@ public typealias GiniCaptureNetworkDelegate = AnalysisDelegate & UploadDelegate
      - parameter importedDocuments: Documents that come from a source different than `CameraViewController`.
      There should be either images or one PDF, and they should be validated before calling this method.
      - parameter trackingDelegate: A delegate object to receive user events
-     - parameter errorLoggerDelegate: A delegate object to log the errors
 
      - returns: A presentable view controller.
      */
     public class func viewController(withDelegate delegate: GiniCaptureDelegate,
                                            importedDocuments: [GiniCaptureDocument]? = nil,
-                                           trackingDelegate: GiniCaptureTrackingDelegate? = nil,
-                                           errorLoggerDelegate: GiniCaptureErrorLoggerDelegate? = nil) -> UIViewController {
+                                           trackingDelegate: GiniCaptureTrackingDelegate? = nil) -> UIViewController {
         let screenCoordinator = GiniScreenAPICoordinator(withDelegate: delegate,
                                                          giniConfiguration: GiniConfiguration.shared)
         screenCoordinator.trackingDelegate = trackingDelegate
-        if GiniConfiguration.shared.giniErrorLoggerIsOn {
-            let customDelegate = GiniConfiguration.shared.customGiniErrorLoggerDelegate
-            screenCoordinator.errorLoggerDelegate = (customDelegate != nil) ? customDelegate : errorLoggerDelegate
-        }
+        screenCoordinator.errorLoggerDelegate = GiniConfiguration.shared.errorLogger
         return screenCoordinator.start(withDocuments: importedDocuments)
     }
     
@@ -230,20 +225,18 @@ public typealias GiniCaptureNetworkDelegate = AnalysisDelegate & UploadDelegate
      - parameter importedDocument: Documents that come from a source different than CameraViewController.
      There should be either images or one PDF, and they should be validated before calling this method.
      - parameter trackingDelegate: A delegate object to receive user events
-     - parameter errorLoggerDelegate: A delegate object to log the errors
 
      - returns: A presentable view controller.
      */
     public class func viewController(withDelegate delegate: GiniCaptureDelegate,
                                            importedDocument: GiniCaptureDocument? = nil,
-                                           trackingDelegate: GiniCaptureTrackingDelegate? = nil,
-                                           errorLoggerDelegate: GiniCaptureErrorLoggerDelegate? = nil) -> UIViewController {
+                                           trackingDelegate: GiniCaptureTrackingDelegate? = nil) -> UIViewController {
         var documents: [GiniCaptureDocument]?
         if let importedDocument = importedDocument {
             documents = [importedDocument]
         }
         
-        return viewController(withDelegate: delegate, importedDocuments: documents, trackingDelegate: trackingDelegate, errorLoggerDelegate: errorLoggerDelegate)
+        return viewController(withDelegate: delegate, importedDocuments: documents, trackingDelegate: trackingDelegate)
     }
     
     /**
@@ -277,17 +270,15 @@ public typealias GiniCaptureNetworkDelegate = AnalysisDelegate & UploadDelegate
      - parameter importedDocument: Documents that come from a source different than CameraViewController.
      There should be either images or one PDF, and they should be validated before calling this method.
      - parameter trackingDelegate: A delegate object to receive user events
-     - parameter errorLoggerDelegate: A delegate object to log the errors
 
      - returns: A presentable view controller.
      */
     public class func viewController(withDelegate delegate: GiniCaptureDelegate,
                                            withConfiguration configuration: GiniConfiguration,
                                            importedDocument: GiniCaptureDocument? = nil,
-                                           trackingDelegate: GiniCaptureTrackingDelegate? = nil,
-                                           errorLoggerDelegate: GiniCaptureErrorLoggerDelegate? = nil) -> UIViewController {
+                                           trackingDelegate: GiniCaptureTrackingDelegate? = nil) -> UIViewController {
         setConfiguration(configuration)
-        return viewController(withDelegate: delegate, importedDocument: importedDocument, trackingDelegate: trackingDelegate,errorLoggerDelegate: errorLoggerDelegate)
+        return viewController(withDelegate: delegate, importedDocument: importedDocument, trackingDelegate: trackingDelegate)
     }
     
     /**

--- a/GiniCapture/Classes/Core/GiniConfiguration.swift
+++ b/GiniCapture/Classes/Core/GiniConfiguration.swift
@@ -628,15 +628,31 @@ import UIKit
     */
     public var customMenuItems: [HelpMenuViewController.Item] = []
     
+    let errorLogger = GiniCaptureErrorLogger()
+    
     /**
      Sets if the default error logging implementation is on
      */
-    @objc public var giniErrorLoggerIsOn = true
+    @objc public var giniErrorLoggerIsOn: Bool {
+        get {
+            return errorLogger.isGiniLoggingOn
+        }
+        set {
+            errorLogger.isGiniLoggingOn = newValue
+        }
+    }
     
     /**
      Should sets if the custom error logging is implemented
      */
-    public var customGiniErrorLoggerDelegate : GiniCaptureErrorLoggerDelegate?
+    public var customGiniErrorLoggerDelegate : GiniCaptureErrorLoggerDelegate? {
+        get {
+            return errorLogger.customErrorLogger
+        }
+        set {
+            errorLogger.customErrorLogger = newValue
+        }
+    }
     
     // Undocumented--Xamarin only
     @objc public var closeButtonResource: PreferredButtonResource?

--- a/GiniCapture/Classes/Core/Logging/GiniCaptureErrorLogger.swift
+++ b/GiniCapture/Classes/Core/Logging/GiniCaptureErrorLogger.swift
@@ -1,0 +1,24 @@
+//
+//  GiniCaptureErrorLogger.swift
+//  GiniCapture
+//
+//  Created by Alpár Szotyori on 27.07.21.
+//
+
+import Foundation
+
+class GiniCaptureErrorLogger: GiniCaptureErrorLoggerDelegate {
+    
+    var isGiniLoggingOn = true
+    var customErrorLogger: GiniCaptureErrorLoggerDelegate? = nil
+    
+    func postGiniErrorLog(error: ErrorLog) {
+        if isGiniLoggingOn {
+            print("GiniScreenAPICoordinator : Error logged to Gini: \(error)")
+        }
+        if let customErrorLogger = customErrorLogger {
+            customErrorLogger.postGiniErrorLog(error: error)
+        }
+    }
+    
+}

--- a/GiniCapture/Classes/Core/Screens/Analysis/AnalysisViewController.swift
+++ b/GiniCapture/Classes/Core/Screens/Analysis/AnalysisViewController.swift
@@ -47,7 +47,6 @@ import UIKit
     fileprivate static let loadingIndicatorContainerHeight: CGFloat = 60
     
     public weak var trackingDelegate: AnalysisScreenTrackingDelegate?
-    public weak var errorLoggerDelegate: GiniCaptureErrorLoggerDelegate?
 
     
     // User interface
@@ -191,10 +190,10 @@ import UIKit
     public func showError(with message: String, action: @escaping () -> Void ) {
         
         trackingDelegate?.onAnalysisScreenEvent(event: Event(type: .error, info: ["message" : message]))
-        if let errorDelegate = errorLoggerDelegate {
-            let errorLog = ErrorLog(description: message)
-            errorDelegate.postGiniErrorLog(error: errorLog)
-        }
+        
+        let errorLog = ErrorLog(description: message)
+        giniConfiguration.errorLogger.postGiniErrorLog(error: errorLog)
+        
         errorView.textLabel.text = message
         errorView.userAction = NoticeAction(title: NoticeActionType.retry.title, action: { [weak self] in
             guard let self = self else { return }

--- a/GiniCapture/Classes/Core/Screens/Camera/CameraViewController.swift
+++ b/GiniCapture/Classes/Core/Screens/Camera/CameraViewController.swift
@@ -68,7 +68,6 @@ import AVFoundation
      */
     public weak var delegate: CameraViewControllerDelegate?
     public weak var trackingDelegate: CameraScreenTrackingDelegate?
-    public weak var errorLoggerDelegate: GiniCaptureErrorLoggerDelegate?
 
     var opaqueView: UIView?
     var fileImportToolTipView: ToolTipView?
@@ -405,12 +404,11 @@ extension CameraViewController {
     private func cameraDidCapture(imageData: Data?, error: CameraError?) {
         guard let imageData = imageData,
             error == nil else {
-            if let errorDelegate = errorLoggerDelegate {
-                let errorLog = ErrorLog(description: "There was an error while capturing a picture: \(String(describing: error?.message))")
-                errorDelegate.postGiniErrorLog(error: errorLog)
-            }
-                assertionFailure("There was an error while capturing a picture")
-                return
+            let errorMessage = error?.message ?? "Image data was nil"
+            let errorLog = ErrorLog(description: "There was an error while capturing a picture: \(String(describing: errorMessage))")
+            giniConfiguration.errorLogger.postGiniErrorLog(error: errorLog)
+            assertionFailure("There was an error while capturing a picture")
+            return
         }
         
         UIImpactFeedbackGenerator(style: .medium).impactOccurred()

--- a/GiniCapture/Classes/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator.swift
+++ b/GiniCapture/Classes/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator.swift
@@ -28,9 +28,6 @@ open class GiniScreenAPICoordinator: NSObject, Coordinator {
     // Tracking
     public weak var trackingDelegate: GiniCaptureTrackingDelegate?
     
-    // Error logging
-    public weak var errorLoggerDelegate: GiniCaptureErrorLoggerDelegate?
-    
     // Screens
     var analysisViewController: AnalysisViewController?
     var cameraViewController: CameraViewController?
@@ -130,12 +127,9 @@ open class GiniScreenAPICoordinator: NSObject, Coordinator {
             }
             
             if let errorMessage = errorMessage {
-                if let errorLogDelegate = errorLoggerDelegate {
-                    let errorLog = ErrorLog(description: errorMessage)
-                    errorLogDelegate.postGiniErrorLog(error: errorLog)
-                } else {
-                    fatalError(errorMessage)
-                }
+                let errorLog = ErrorLog(description: errorMessage)
+                giniConfiguration.errorLogger.postGiniErrorLog(error: errorLog)
+                fatalError(errorMessage)
             }
         } else {
             self.cameraViewController = self.createCameraViewController()
@@ -278,16 +272,13 @@ extension GiniScreenAPICoordinator {
             visionDelegate?.didReview(documents: pages.map { $0.document }, networkDelegate: self)
         }
         analysisViewController = createAnalysisScreen(withDocument: firstDocument)
-        analysisViewController?.errorLoggerDelegate = errorLoggerDelegate
         analysisViewController?.trackingDelegate = trackingDelegate
         
         if let (message, action) = analysisErrorAndAction {
             
             displayError(withMessage: message, andAction: action)
-            if let errorDelegate = errorLoggerDelegate {
-                let errorLog = ErrorLog(description: message)
-                errorDelegate.postGiniErrorLog(error: errorLog)
-            }
+            let errorLog = ErrorLog(description: message)
+            giniConfiguration.errorLogger.postGiniErrorLog(error: errorLog)
         }
         
         self.screenAPINavigationController.pushViewController(analysisViewController!, animated: true)

--- a/GiniCapture/Classes/Networking/Extensions/GiniCapture+GiniCaptureDelegate.swift
+++ b/GiniCapture/Classes/Networking/Extensions/GiniCapture+GiniCaptureDelegate.swift
@@ -43,8 +43,7 @@ extension GiniCapture {
                                                          documentMetadata: documentMetadata,
                                                          api: api,
                                                          userApi: userApi,
-                                                         trackingDelegate: trackingDelegate,
-                                                         errorLoggerDelegate: errorLoggerDelegate)
+                                                         trackingDelegate: trackingDelegate)
         return screenCoordinator.start(withDocuments: importedDocuments)
     }
     

--- a/GiniCapture/Classes/Networking/GiniNetworkingScreenAPICoordinator.swift
+++ b/GiniCapture/Classes/Networking/GiniNetworkingScreenAPICoordinator.swift
@@ -46,7 +46,6 @@ import GiniPayApiLib
          documentMetadata: Document.Metadata?,
          api: APIDomain,
          trackingDelegate: GiniCaptureTrackingDelegate?,
-         errorLoggerDelegate: GiniCaptureErrorLoggerDelegate?,
          lib : GiniApiLib) {
 
         self.documentService = GiniNetworkingScreenAPICoordinator.documentService(with: lib,
@@ -59,7 +58,6 @@ import GiniPayApiLib
         self.visionDelegate = self
         self.resultsDelegate = resultsDelegate
         self.trackingDelegate = trackingDelegate
-        self.errorLoggerDelegate = errorLoggerDelegate
     }
     
     convenience init(client: Client,
@@ -68,8 +66,7 @@ import GiniPayApiLib
                      documentMetadata: Document.Metadata?,
                      api: APIDomain,
                      userApi: UserDomain,
-                     trackingDelegate: GiniCaptureTrackingDelegate?,
-                     errorLoggerDelegate: GiniCaptureErrorLoggerDelegate?) {
+                     trackingDelegate: GiniCaptureTrackingDelegate?) {
         
         let lib = GiniApiLib
             .Builder(client: client, api: api, userApi: userApi)
@@ -81,7 +78,6 @@ import GiniPayApiLib
                   documentMetadata: documentMetadata,
                   api: api,
                   trackingDelegate: trackingDelegate,
-                  errorLoggerDelegate: errorLoggerDelegate,
                   lib: lib)
     }
     


### PR DESCRIPTION
Introduced `GiniCaptureErrorLogger` to contain the error logging logic and avoid having it in multiple places.

The error logging configuration in `GiniConfiguration` forwards the settings to and from the `GiniCaptureErrorLogger`.

Allowing a custom error logger delegate to be set only in `GiniConfiguration`. It was confusing to be also able to set a custom one in the `viewController()` methods.

Always using the error logger instance from `GiniConfiguration`. This makes sure our error logger is always called also when using the component api.