### PR TITLE
Show an error when none of the picked files could be opened

### DIFF
--- a/Example/Example Swift/AppCoordinator.swift
+++ b/Example/Example Swift/AppCoordinator.swift
@@ -92,6 +92,8 @@ final class AppCoordinator: Coordinator {
                 } catch {
                     self.showExternalDocumentNotValidDialog()
                 }
+            } else {
+                self.showExternalDocumentNotValidDialog()
             }
         }
     }

--- a/Example/Example Swift/ComponentAPICoordinator.swift
+++ b/Example/Example Swift/ComponentAPICoordinator.swift
@@ -533,7 +533,7 @@ extension ComponentAPICoordinator: DocumentPickerCoordinatorDelegate {
                             }
                         }
                         
-                    case .photoLibraryAccessDenied:
+                    case .photoLibraryAccessDenied, .failedToOpenDocument:
                         break
                     }
                 }
@@ -548,7 +548,18 @@ extension ComponentAPICoordinator: DocumentPickerCoordinatorDelegate {
             }
             
         }
-    }    
+    }
+    
+    func documentPicker(_ coordinator: DocumentPickerCoordinator, failedToPickDocumentsAt urls: [URL]) {
+        let error = FilePickerError.failedToOpenDocument
+        if coordinator.currentPickerDismissesAutomatically {
+            self.cameraScreen?.showErrorDialog(for: error,
+                                               positiveAction: nil)
+        } else {
+            coordinator.currentPickerViewController?.showErrorDialog(for: error,
+                                                                     positiveAction: nil)
+        }
+    }
 }
 
 // MARK: - ReviewViewControllerDelegate

--- a/Example/Example Swift/UIViewController.swift
+++ b/Example/Example Swift/UIViewController.swift
@@ -45,6 +45,8 @@ extension UIViewController {
                 confirmActionTitle = NSLocalizedString("ginicapture.camera.mixedarrayspopup.usePhotos",
                                                        bundle: Bundle(for: GiniCapture.self),
                                                        comment: "use photos button text in popup")
+            case .failedToOpenDocument:
+                break
             }
         case let visionError as CustomAnalysisError:
             message = visionError.message

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -22,7 +22,7 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - Bolts
-  https://github.com/gini/gini-podspecs.git:
+  https://github.com/gini/gini-podspecs:
     - Gini-iOS-SDK
     - GiniPayApiLib
 
@@ -38,4 +38,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 4388413edb9a8300e79cf2b4ad755c81370a6ec0
 
-COCOAPODS: 1.11.0.beta.2
+COCOAPODS: 1.11.2

--- a/GiniCapture/Assets/de.lproj/Localizable.strings
+++ b/GiniCapture/Assets/de.lproj/Localizable.strings
@@ -27,6 +27,7 @@
 "ginicapture.camera.captureFailed" = "Bilderfassung fehlgeschlagen";
 "ginicapture.camera.filepicker.photoLibraryAccessDenied" = "Um gespeicherte Bilder zu analysieren, wird Zugriff auf Ihre Fotos benötigt.";
 "ginicapture.camera.filepicker.mixedDocumentsUnsupported" = "Es ist nur möglich einen Dateityp gleichzeitig auszuwählen.";
+"ginicapture.camera.filepicker.failedToOpenDocument" = "Die Datei konnte nicht geöffnet werden. Bitte verwenden Sie einen anderen Dateityp.";
 "ginicapture.camera.filepicker.errorPopup.cancelButton" = "Abbrechen";
 "ginicapture.camera.filepicker.errorPopup.confirmButton" = "OK";
 "ginicapture.camera.filepicker.errorPopup.grantAccessButton" = "Zugriff erteilen";

--- a/GiniCapture/Assets/en.lproj/Localizable.strings
+++ b/GiniCapture/Assets/en.lproj/Localizable.strings
@@ -27,6 +27,7 @@
 "ginicapture.camera.captureFailed" = "Image capture failed";
 "ginicapture.camera.filepicker.photoLibraryAccessDenied" = "Permission to access your photos gallery is required to analyse saved photos";
 "ginicapture.camera.filepicker.mixedDocumentsUnsupported" = "It is only possible to select one file type at the same time.";
+"ginicapture.camera.filepicker.failedToOpenDocument" = "The file could not be opened. Please use a different file type.";
 "ginicapture.camera.filepicker.errorPopup.cancelButton" = "Cancel";
 "ginicapture.camera.filepicker.errorPopup.confirmButton" = "OK";
 "ginicapture.camera.filepicker.errorPopup.grantAccessButton" = "Grant permission";

--- a/GiniCapture/Classes/Core/Extensions/UIViewController.swift
+++ b/GiniCapture/Classes/Core/Extensions/UIViewController.swift
@@ -57,6 +57,8 @@ extension UIViewController {
             case .mixedDocumentsUnsupported:
                 cancelActionTitle = .localized(resource: CameraStrings.mixedArraysPopupCancelButton)
                 confirmActionTitle = .localized(resource: CameraStrings.mixedArraysPopupUsePhotosButton)
+            case .failedToOpenDocument:
+                break
             }
         default:
             message = DocumentValidationError.unknown.message

--- a/GiniCapture/Classes/Core/Helpers/Localization/String Resources/CameraStrings.swift
+++ b/GiniCapture/Classes/Core/Helpers/Localization/String Resources/CameraStrings.swift
@@ -15,7 +15,8 @@ enum CameraStrings: LocalizableStringResource {
     mixedArraysPopupCancelButton, mixedArraysPopupUsePhotosButton, mixedDocumentsErrorMessage, notAuthorizedButton,
     notAuthorizedMessage, photoLibraryAccessDeniedMessage, qrCodeDetectedPopupMessage, qrCodeDetectedPopupButton,
     tooManyPagesErrorMessage, unknownErrorMessage, wrongFormatErrorMessage, popupTitleImportPDF, popupOptionPhotos,
-    popupOptionFiles, popupTitleImportPDForPhotos, popupCancel, unsupportedQrCodeDetectedPopupMessage
+    popupOptionFiles, popupTitleImportPDForPhotos, popupCancel, unsupportedQrCodeDetectedPopupMessage,
+    failedToOpenDocumentErrorMessage
     
     var tableName: String {
         return "camera"
@@ -90,7 +91,9 @@ enum CameraStrings: LocalizableStringResource {
             return ("unsupportedQrCodeDetectedPopup.message", "Popup message")
         case .qrCodeTipLabel:
             return ("qrCodeTip", "tooltip text indicating new qr code feature")
-
+        case .failedToOpenDocumentErrorMessage:
+            return ("filepicker.failedToOpenDocument",
+                    "Error message when the the picked document couldn't be opened")
         }
     }
     
@@ -101,7 +104,7 @@ enum CameraStrings: LocalizableStringResource {
              .exceededFileSizeErrorMessage, .documentValidationGeneralErrorMessage,
              .mixedArraysPopupCancelButton, .mixedArraysPopupUsePhotosButton, .mixedDocumentsErrorMessage,
              .notAuthorizedButton, .notAuthorizedMessage, .photoLibraryAccessDeniedMessage, .qrCodeDetectedPopupMessage,
-             .qrCodeDetectedPopupButton, .tooManyPagesErrorMessage, .unknownErrorMessage, .wrongFormatErrorMessage, .unsupportedQrCodeDetectedPopupMessage, .fileImportTipLabel, .qrCodeTipLabel, .importFileButtonLabel:
+             .qrCodeDetectedPopupButton, .tooManyPagesErrorMessage, .unknownErrorMessage, .wrongFormatErrorMessage, .unsupportedQrCodeDetectedPopupMessage, .fileImportTipLabel, .qrCodeTipLabel, .importFileButtonLabel, .failedToOpenDocumentErrorMessage:
             return true
         case .capturedImagesStackSubtitleLabel, .popupTitleImportPDF,
              .popupTitleImportPDForPhotos, .popupOptionPhotos, .popupOptionFiles, .popupCancel:

--- a/GiniCapture/Classes/Core/Models/GiniError.swift
+++ b/GiniCapture/Classes/Core/Models/GiniError.swift
@@ -73,6 +73,9 @@ public protocol GiniCaptureError: Error {
     /// Mixed documents unsupported
     case mixedDocumentsUnsupported
     
+    /// Could not open the document (data could not be read or unsupported file type or some other issue)
+    case failedToOpenDocument
+    
     public var message: String {
         switch self {
         case .photoLibraryAccessDenied:
@@ -81,7 +84,8 @@ public protocol GiniCaptureError: Error {
             return .localized(resource: CameraStrings.tooManyPagesErrorMessage)
         case .mixedDocumentsUnsupported:
             return .localized(resource: CameraStrings.mixedDocumentsErrorMessage)
-
+        case .failedToOpenDocument:
+            return .localized(resource: CameraStrings.failedToOpenDocumentErrorMessage)
         }
     }
 }

--- a/GiniCapture/Classes/Core/Screens/Document picker/DocumentPickerCoordinator.swift
+++ b/GiniCapture/Classes/Core/Screens/Document picker/DocumentPickerCoordinator.swift
@@ -18,20 +18,21 @@ import MobileCoreServices
 public protocol DocumentPickerCoordinatorDelegate: AnyObject {
     /**
      Called when a user picks one or several files from either the gallery or the files explorer.
-     The completion might provide errors that must be handled here before dismissing the
-     pickers. It only applies to the `GalleryCoordinator` since on one side it is not possible
-     to handle the dismissal of UIDocumentPickerViewController and on the other side
-     the Drag&Drop is not done in a separate view.
      
      - parameter coordinator: `DocumentPickerCoordinator` where the documents were imported.
      - parameter documents: One or several documents imported.
-     - parameter from: Picker used (either gallery, files explorer or drag&drop).
-     - parameter validationHandler: `DocumentValidationHandler` block used to check if there is an issue with
-     the captured documents. The handler has an inner completion block that is executed once the
-     picker has been dismissed when there are no errors.
      */
     func documentPicker(_ coordinator: DocumentPickerCoordinator,
                         didPick documents: [GiniCaptureDocument])
+    
+    /**
+     Called when the picked documents could not be opened.
+     
+     - parameter coordinator: `DocumentPickerCoordinator` where the documents were imported.
+     - parameter urls: URLs of the picked documents.
+     */
+    func documentPicker(_ coordinator: DocumentPickerCoordinator,
+                        failedToPickDocumentsAt urls: [URL])
 }
 
 /**
@@ -330,6 +331,11 @@ extension DocumentPickerCoordinator: UIDocumentPickerDelegate {
         let documents: [GiniCaptureDocument] = urls
             .compactMap(self.data)
             .compactMap(self.createDocument)
+        
+        guard documents.isNotEmpty else {
+            delegate?.documentPicker(self, failedToPickDocumentsAt: urls)
+            return
+        }
         
         if #available(iOS 11.0, *), giniConfiguration.documentPickerNavigationBarTintColor != nil {
             restoreSavedNavBarAppearance()

--- a/GiniCapture/Classes/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Camera.swift
+++ b/GiniCapture/Classes/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Camera.swift
@@ -219,7 +219,7 @@ extension GiniScreenAPICoordinator: DocumentPickerCoordinatorDelegate {
                             }
                         }
                         
-                    case .photoLibraryAccessDenied:
+                    case .photoLibraryAccessDenied, .failedToOpenDocument:
                         break
                     }
                 }
@@ -233,6 +233,17 @@ extension GiniScreenAPICoordinator: DocumentPickerCoordinatorDelegate {
                 }
             }
             
+        }
+    }
+    
+    public func documentPicker(_ coordinator: DocumentPickerCoordinator, failedToPickDocumentsAt urls: [URL]) {
+        let error = FilePickerError.failedToOpenDocument
+        if coordinator.currentPickerDismissesAutomatically {
+            self.cameraViewController?.showErrorDialog(for: error,
+                                                       positiveAction: nil)
+        } else {
+            coordinator.currentPickerViewController?.showErrorDialog(for: error,
+                                                                     positiveAction: nil)
         }
     }
     


### PR DESCRIPTION
If none of the picked files can be converted to `GiniVisionDocuments`
then a new `DocumentPickerCoordinatorDelegate` method is called. In
this case an error dialog is shown with the new
`FilePickerError.failedToOpenDocument` error.

https://ginis.atlassian.net/browse/PIA-1477

